### PR TITLE
optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,28 +1,28 @@
-module.exports = vonNeumann;
+module.exports = function vonNeumann(range, dimensions) {
+  range = range || 1
+  dimensions = dimensions || 2
 
-function vonNeumann(range, dims) {
-    dims = dims || 2;
-    range = range || 1;
-    return recurse([], [], 0);
-
-    function recurse(array, temp, d) {
-        var manhattanDistance,
-            i;
-
-        if (d === dims-1) {
-            for (i = -range; i <= range; i += 1) {
-                manhattanDistance = temp.reduce(function (sum, value) { return sum + Math.abs(value); }, Math.abs(i));
-
-                if (manhattanDistance <= range && manhattanDistance !== 0) {
-                    array.push(temp.concat(i));
-                }
-            }
-        } else {
-            for (i = -range; i <= range; i += 1) {
-                recurse(array, temp.concat(i), d + 1);
-            }
-        }
-
-        return array;
+  var size = range * 2 + 1
+  var iterations = Math.pow(size, dimensions)
+  var center = (iterations - 1) / 2
+  var neighbors = []
+  for (var i = 0; i < iterations; i++) {
+    if (i !== center) {
+      var neighbor = new Array(dimensions)
+      var distance = 0
+      var remaining = i
+      for (var d = 0; d < dimensions; d++) {
+        var remainder = remaining % Math.pow(size, d + 1)
+        var value = remainder / Math.pow(size, d) - range
+        neighbor[d] = value
+        distance += Math.abs(value)
+        remaining -= remainder
+      }
+      if (distance <= range) {
+        neighbors.push(neighbor)
+      }
     }
+  }
+
+  return neighbors
 }


### PR DESCRIPTION
hi, decided to try my hand at optimizing this module after doing some stuff with `hughsk/moore`. New version is ~5x faster and passes tests:thumbsup:
```md
# old version 1000000 times
ok ~5.33 s (5 s + 328003895 ns)

# new version 1000000 times
ok ~1.01 s (1 s + 11613949 ns)
```
this is unarguably a more complicated algorithm to implement. I was actually planning on using [`semibran/delannoy`](https://github.com/semibran/delannoy) to calculate the number of cells in the desired neighborhood, which would allow the algorithm to allocate the necessary memory beforehand. however, I found that it would be implausible to add that inline and I thought it would be a bad idea to add extra dependencies :grimacing:

I'll try to trim it down and see what I can come up with. if it works out, I might be able to get an extra speed boost.